### PR TITLE
chore: Upgrade AGP, Kotlin, Gradle, migrate to kts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,17 @@
-buildscript {
-    ext {
-        kotlin_version = '1.4.10'
-    }
+plugins {
+    id "org.sonarqube" version"3.3" apply true
+    id "org.jlleitschuh.gradle.ktlint" version "10.2.1" apply true
 
-    repositories {
-        jcenter()
-        google()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
 }
 
 allprojects {
-    group = 'com.mparticle'
-    version = '1.3.1-SNAPSHOT'
+    group = project.properties["group"].toString()
+    version = project.properties["version"].toString()
     if (project.hasProperty('isRelease') && project.isRelease) {
         version = version.toString().replace("-SNAPSHOT", "")
+    }
+    repositories {
+        google()
+        mavenCentral()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,6 @@
 kotlin.code.style=official
 android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+group=com.mparticle
+version=0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -1,11 +1,6 @@
-import org.sonarqube.gradle.SonarQubeExtension
-
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
-    id("org.sonarqube").version("2.7")
-
 }
 
 ext["kitDescription"] = "Media Api to supplement core SDK"
@@ -13,32 +8,31 @@ ext["kitDescription"] = "Media Api to supplement core SDK"
 apply(from= "../scripts/maven.gradle")
 
 android {
+    compileSdk = 31
     defaultConfig {
-        minSdkVersion(16)
-        compileSdkVersion(28)
+        minSdk = 16
+        targetSdk = 31
     }
 }
 
 repositories {
-    jcenter()
-    mavenLocal()
+    mavenCentral()
     google()
 }
 
-
 dependencies {
-    testImplementation(files("libs/test-utils.aar"))
-    testImplementation(files("libs/java-json.jar"))
-    testImplementation("junit:junit:4.12")
-
     implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
     implementation("com.mparticle:android-core:[5.11.3,)")
 
+    testImplementation(files("libs/test-utils.aar"))
+    testImplementation(files("libs/java-json.jar"))
+    testImplementation("junit:junit:4.12")
 }
-configure<SonarQubeExtension> {
+
+configure<org.sonarqube.gradle.SonarQubeExtension> {
     properties {
         property("sonar.projectName", "Android")
-        property("sonar.prjectKey", "Android")
+        property("sonar.projectKey", "Android")
     }
 }
 

--- a/media/settings.gradle
+++ b/media/settings.gradle
@@ -1,1 +1,0 @@
-include ':shared'

--- a/media/src/main/java/com/mparticle/media/events/MediaError.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaError.kt
@@ -1,0 +1,4 @@
+package com.mparticle.media.events
+
+class MediaError {
+}

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -1,4 +1,5 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 allprojects {
     ext."signing.keyId" = System.getenv("mavenSigningKeyId")
@@ -6,82 +7,113 @@ allprojects {
     ext."signing.password" = System.getenv("mavenSigningKeyPassword")
 }
 
-configurations {
-    deployerJars
-}
-
-dependencies {
-    deployerJars "org.kuali.maven.wagons:maven-s3-wagon:1.2.1"
-}
-
-def target_maven_repo
-if (project.hasProperty('target_maven_repo')) {
-    target_maven_repo = project.property('target_maven_repo')
-}
-
-if (target_maven_repo in ['sonatype', 'sonatype-snapshot']) {
-    apply plugin: 'signing'
-    signing {
-        required { gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
-    }
-}
-
-
-
-uploadArchives{
-    repositories {
-        mavenDeployer {
-            if (target_maven_repo == 'sonatype') {
-                beforeDeployment {
-                    MavenDeployment deployment -> signing.signPom(deployment)
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId = "com.mparticle"
+                artifactId = project.name
+                version = project.version
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.release
+                } else {
+                    from components.java
                 }
-                repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                    authentication(userName: System.getenv('sonatypeUsername'), password: System.getenv('sonatypePassword'))
-                }
-            } else if (target_maven_repo == 'sonatype-snapshot') {
-                beforeDeployment {
-                    MavenDeployment deployment -> signing.signPom(deployment)
-                }
-                repository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                    authentication(userName: System.getenv('sonatypeUsername'), password: System.getenv('sonatypePassword'))
-                }
-            } else if (target_maven_repo == 's3') {
-                configuration = configurations.deployerJars
-                repository(url: 's3://maven.mparticle.com')
-            } else {
-                repository(url: 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath)
-            }
 
-            pom.project {
-                version project.version
-                artifactId 'android-media'
-                packaging 'aar'
-                name project.ext.kitDescription
-                description project.ext.kitDescription
-                url 'https://github.com/mParticle/mparticle-android-media-sdk'
+                if (project.tasks.findByName('generateJavadocsJar')) {
+                    artifact project.tasks.getByName('mediaSdkJavadoc')
+                }
+                if (project.tasks.findByName('generateSourcesJar')) {
+                    artifact project.tasks.getByName('generateSourcesJar')
+                }
 
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                pom {
+                    name = project.ext.kitDescription
+                    description = project.ext.kitDescription
+                    url = "https://github.com/mParticle/mparticle-android-media-sdk"
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'https://www.apache.org/license/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'mParticle'
+                            name = 'mParticle Inc.'
+                            email = 'developers@mparticle.com'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/mparticle/mparticle-android-media-sdk'
+                        connection = 'scm:git:https://github.com/mparticle/mparticle-android-media-sdk'
+                        developerConnection = 'scm:git:git@github.com:mparticle/mparticle-android-media-sdk.git'
                     }
                 }
-
-                scm {
-                    url 'https://github.com/mParticle/mparticle-android-media-sdk'
-                    connection 'scm:git@github.com:mParticle/mparticle-android-media-sdk.git'
-                    developerConnection 'scm:git@github.com:mParticle/mparticle-android-media-sdk.git'
+            }
+            debug(MavenPublication) {
+                groupId = "com.mparticle"
+                artifactId = "android-media"
+                version = project.version
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.debug
+                } else {
+                    from components.java
                 }
 
-                developers {
-                    developer {
-                        id 'mParticle'
-                        name 'mParticle Inc.'
-                        email 'developers@mparticle.com'
+                if (project.tasks.findByName('generateJavadocsJar')) {
+                    artifact project.tasks.getByName('generateJavadocsJar')
+                }
+
+                if (project.tasks.findByName('generateSourcesJar')) {
+                    artifact project.tasks.getByName('generateSourcesJar')
+                }
+
+                pom {
+                    name = project.ext.kitDescription
+                    description = project.ext.kitDescription
+                    url = 'https://github.com/mparticle/mparticle-sdk-android'
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'https://www.apache.org/license/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'mParticle'
+                            name = 'mParticle Inc.'
+                            email = 'developers@mparticle.com'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/mparticle/mparticle-android-sdk'
+                        connection = 'scm:git:https://github.com/mparticle/mparticle-android-sdk'
+                        developerConnection = 'scm:git:git@github.com:mparticle/mparticle-android-sdk.git'
                     }
                 }
             }
         }
+        repositories {
+            maven {
+                credentials {
+                    username System.getenv('sonatypeUsername')
+                    password System.getenv('sonatypePassword')
+                }
+                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            }
+        }
+    }
+
+    def signingKey = System.getenv("mavenSigningKeyId")
+    def signingPassword = System.getenv("mavenSigningKeyPassword")
+    signing {
+        required { gradle.taskGraph.hasTask("publishReleasePublicationToMavenRepository") }
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.release
     }
 }
+
+//Publishing task aliases for simpler local development
+task publishLocal { dependsOn "publishDebugPublicationToMavenLocal" }
+task publishReleaseLocal { dependsOn "publishReleasePublicationToMavenLocal" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-include ':media'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,13 @@
+include("media")
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id("com.android.library") version "7.1.3"
+        id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+        kotlin("android") version "1.6.20"
+    }
+}


### PR DESCRIPTION
## Summary
Upgrade:
- AGP 7.1.3
- Gradle 7.3.2
- Kotlin 1.6.20
- targetSdk = 31
-`maven` plugin -> `maven-publish`
- + `signing` plugin
- `settings.gradle` -> `settings.gradle.kts`

Also moved the plugin definitions from `build.gradle.kts` -> `settings.gradle.kts`. I think it comes out a lot cleaner that way  :)

## Testing Plan
manually verified `aar`, `.pom` artifacts generated by the publish job hasn't changed

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3678
