### PR TITLE
feat: add MediaSession#logError() endpoint

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,26 +27,26 @@ jobs:
         with:
           name: "unit-tests-results"
           path: ./**/build/reports/**
-#  lint-checks:
-#    name: "Lint Checks"
-#    timeout-minutes: 15
-#    runs-on: macos-latest
-#    steps:
-#      - name: "Checkout Branch"
-#        uses: actions/checkout@v2
-#      - name: "Install JDK 11"
-#        uses: actions/setup-java@v2
-#        with:
-#          distribution: "zulu"
-#          java-version: "11"
-#      - name: "Run Android Core SDK Lint"
-#        run: ./gradlew lint
-#      - name: "Archive Lint Test Results"
-#        uses: actions/upload-artifact@v2
-#        if: ${{ always() }}
-#        with:
-#          name: "lint-results"
-#          path: ./**/build/reports/**
+  lint-checks:
+    name: "Lint Checks"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Branch"
+        uses: actions/checkout@v2
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Run Lint"
+        run: ./gradlew lint --info
+      - name: "Archive Lint Test Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: "lint-results"
+          path: ./**/build/reports/**
   kotlin-lint-checks:
     name: "Kotlin Lint Checks"
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Starting a MediaSession and logging events. The `MediaSession` fields `title`, `
     //start the MediaSession
     mediaSession.logMediaSessionStart()
     
-    //log events!
+    //log events
     mediaSession.logPlay()
     mediaSession.logPause()
 ```
@@ -117,7 +117,20 @@ mediaSession.mediaEventListener = { mediaEvent ->
 }
 ```
 
+#### Logging Media Errors
 
+The `MediaSession#logError(String, Map)` method is similar to the generic `MParticle#logError(String, Map)` method, but should be used for logging events specific to an individual `MediaSession`.
+
+Like all other `Media` events, "Error" events will not be sent to the MParticle Server by default, but will be consumed by local kits. To log this event to the MParticle Server, follow [the previously outlined instructions](#logging-mediaevents-as-custom-events-mpevent-to-the-mparticle-server)
+
+example: 
+```kotlin
+//log a MediaSession-specific error as a MediaEvent
+mediaSession.logError("Player Crashed", mapOf("foo", "bar"))
+
+//log a general error as an core event
+MParticle.getInstance()?.logError("Request timed out", mapOf("foo", "bar"))
+```
 
 # Contibution Guidelines
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xms128m -Xmx2560m -XX:+CMSClassUnloadingEnabled
 group=com.mparticle
 version=1.3.2

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -62,7 +62,7 @@ class MediaSession protected constructor(builder: Builder) {
         internal set
     var sessionQoS = MediaQoS()
 
-    var attributes: MutableMap<String, String> = mutableMapOf()
+    var attributes: MutableMap<String, Any?> = mutableMapOf()
         get() = MediaEvent(this).getSessionAttributes()
         private set
 
@@ -427,6 +427,20 @@ class MediaSession protected constructor(builder: Builder) {
         val mediaQos = MediaQoS()
         mediaQos.builder()
         logQos(mediaQos, options)
+    }
+
+    /**
+     * Log a MediaEvent of type {@link MediaEventName.ERROR}. For these events, you will be able
+     * to query the {@link MediaEvent#error} field
+     *
+     * @param message the error message
+     * @param attributes a Map of addition information about the error
+     */
+    fun logError(message: String, attributes: Map<String, Any?> = mapOf(), options: Options? = null) {
+        val errorEvent = MediaEvent(this, MediaEventName.ERROR, options = options).apply {
+            error = MediaError(message, attributes)
+        }
+        logEvent(errorEvent)
     }
 
     /**

--- a/media/src/main/java/com/mparticle/media/events/MediaAttributeKeys.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaAttributeKeys.kt
@@ -54,4 +54,8 @@ object MediaAttributeKeys {
     const val SEGMENT_TITLE = "segment_title"
     const val SEGMENT_INDEX = "segment_index"
     const val SEGMENT_DURATION = "segment_duration"
+
+    //Error
+    const val ERROR_MESSAGE = "error_message"
+    const val ERROR_ATTRIBUTES = "error_attributes"
 }

--- a/media/src/main/java/com/mparticle/media/events/MediaError.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaError.kt
@@ -1,4 +1,3 @@
 package com.mparticle.media.events
 
-class MediaError {
-}
+class MediaError(val message: String, val attributes: Map<String, Any?> = mapOf())

--- a/media/src/main/java/com/mparticle/media/events/MediaEventName.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaEventName.kt
@@ -21,4 +21,5 @@ object MediaEventName {
     const val SEGMENT_END = "Segment End"
     const val SEGMENT_SKIP = "Segment Skip"
     const val UPDATE_QOS = "Update QoS"
+    const val ERROR = "Error"
 }

--- a/media/src/main/java/com/mparticle/media/events/Options.kt
+++ b/media/src/main/java/com/mparticle/media/events/Options.kt
@@ -12,3 +12,6 @@ class Options(
      */
     var customAttributes: Map<String, String> = mutableMapOf()
 )
+
+@JvmSynthetic
+fun Options(builder: Options.() -> Unit): Options = Options().apply(builder)

--- a/media/src/main/java/com/mparticle/media/internal/Logger.kt
+++ b/media/src/main/java/com/mparticle/media/internal/Logger.kt
@@ -115,6 +115,7 @@ object Logger {
                     MParticle.LogLevel.DEBUG -> debug(error, messages)
                     MParticle.LogLevel.VERBOSE -> verbose(error, messages)
                     MParticle.LogLevel.INFO -> info(error, messages)
+                    else -> info(error, messages)
                 }
             }
         }
@@ -149,43 +150,43 @@ object Logger {
 
     open class DefaultLogHandler : AbstractLogHandler() {
 
-        public override fun verbose(error: Throwable?, messages: String) {
+        public override fun verbose(error: Throwable?, message: String) {
             if (error != null) {
-                Log.v(LOG_TAG, messages, error)
+                Log.v(LOG_TAG, message, error)
             } else {
-                Log.v(LOG_TAG, messages)
+                Log.v(LOG_TAG, message)
             }
         }
 
-        public override fun info(error: Throwable?, messages: String) {
+        public override fun info(error: Throwable?, message: String) {
             if (error != null) {
-                Log.i(LOG_TAG, messages, error)
+                Log.i(LOG_TAG, message, error)
             } else {
-                Log.i(LOG_TAG, messages)
+                Log.i(LOG_TAG, message)
             }
         }
 
-        public override fun debug(error: Throwable?, messages: String) {
+        public override fun debug(error: Throwable?, message: String) {
             if (error != null) {
-                Log.d(LOG_TAG, messages, error)
+                Log.d(LOG_TAG, message, error)
             } else {
-                Log.d(LOG_TAG, messages)
+                Log.d(LOG_TAG, message)
             }
         }
 
-        public override fun warning(error: Throwable?, messages: String) {
+        public override fun warning(error: Throwable?, message: String) {
             if (error != null) {
-                Log.w(LOG_TAG, messages, error)
+                Log.w(LOG_TAG, message, error)
             } else {
-                Log.w(LOG_TAG, messages)
+                Log.w(LOG_TAG, message)
             }
         }
 
-        public override fun error(error: Throwable?, messages: String) {
+        public override fun error(error: Throwable?, message: String) {
             if (error != null) {
-                Log.e(LOG_TAG, messages, error)
+                Log.e(LOG_TAG, message, error)
             } else {
-                Log.e(LOG_TAG, messages)
+                Log.e(LOG_TAG, message)
             }
         }
     }

--- a/media/src/test/java/com/mparticle/APISampleJava.java
+++ b/media/src/test/java/com/mparticle/APISampleJava.java
@@ -5,19 +5,30 @@ import com.mparticle.media.events.ContentType;
 import com.mparticle.media.events.MediaEvent;
 import com.mparticle.media.events.StreamType;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
 
 public class APISampleJava {
+    private MediaSession mediaSession = null;
 
-    public void main() {
-        MediaSession mediaSession = MediaSession.builder()
+    @Before
+    public void before() {
+        mediaSession = MediaSession.builder()
                 .duration(123L)
                 .title("Media Title ")
                 .mediaContentId("abc123")
                 .contentType(ContentType.AUDIO)
                 .streamType(StreamType.LIVE_STEAM)
                 .build();
+    }
+
+    @Test
+    public void main() {
         mediaSession.setMediaEventListener(new Function1<MediaEvent, Unit>() {
             @Override
             public Unit invoke(MediaEvent mediaEvent) {

--- a/media/src/test/java/com/mparticle/APISampleKotlin.kt
+++ b/media/src/test/java/com/mparticle/APISampleKotlin.kt
@@ -5,68 +5,99 @@ import com.mparticle.media.MediaSession
 import com.mparticle.media.events.*
 import com.mparticle.media.events.EventAttributes.CONTENT_EPISODE
 import com.mparticle.media.events.EventAttributes.PLAYER_NAME
+import org.junit.Before
+import org.junit.Test
 
 
-fun main() {
+class APISampleKotlin {
+    lateinit var mediaSession: MediaSession
 
+    @Before
+    fun before() {
+        //log MPEvents, don't log MediaEvents
+        mediaSession = MediaSession.builder {
+            title = "Media Title"
+            mediaContentId = "123"
+            duration = 1000
+            streamType = StreamType.LIVE_STEAM
+            contentType = ContentType.VIDEO
 
-    //log MPEvents, don't log MediaEvents
-    val mediaSession = MediaSession.builder {
-        title = "Media Title"
-        mediaContentId = "123"
-        duration = 1000
-        streamType = StreamType.LIVE_STEAM
-        contentType = ContentType.VIDEO
-
-        logMediaEvents = false
-        logMPEvents = true
-    }
-
-    //log a custom event, type "Milestone" with customAttributes ["type", "95%"]
-    val mpEvent = mediaSession.buildMPEvent("Milestone", mapOf(
-        "type" to "95%"
-    ))
-    MParticle.getInstance()?.logEvent(mpEvent)
-
-
-    //listen for Media events type PLAY, PAUSE, CONTENT_END
-    mediaSession.mediaEventListener = { mediaEvent ->
-        if (mediaEvent.eventName == MediaEventName.PLAY) {
-            val mpEvent = mediaEvent.toMPEvent()
-            MParticle.getInstance()?.logEvent(mpEvent)
+            logMediaEvents = false
+            logMPEvents = true
         }
     }
 
-    var options = Options(currentPlayheadPosition = 120000)
-
-    mediaSession.logPlay(options)
-
-
-
-
-    //log some MediaEvents
-    mediaSession.logAdStart {
-        id = "4423210"
-        advertiser = "Moms Friendly Robot Company"
-        title = "What?! Nobody rips off my kids but me!"
-        campaign = "MomCorp Galactic Domination Plot 3201"
-        duration = 60000
-        creative = "A Fistful of Dollars"
-        siteId = "moms"
-        placement = "first"
-        position = 0
-    }
-     options = Options(
-        customAttributes = mapOf(
-            "isFullScreen" to "true",
-            CONTENT_EPISODE to "episode1",
-            PLAYER_NAME to "JWPlayer"
+    @Test
+    fun buildMPEvent() {
+        //log a custom event, type "Milestone" with customAttributes ["type", "95%"]
+        mediaSession.buildMPEvent(
+            "Milestone", mapOf(
+                "type" to "95%"
+            )
         )
-    )
+    }
 
-    mediaSession.logAdBreakStart {
-        id = "123456"
-        title = "pre-roll"
-        duration = 6000
+    @Test
+    fun logAdStartBuilder() {
+//log some MediaEvents
+        mediaSession.logAdStart {
+            id = "4423210"
+            advertiser = "Moms Friendly Robot Company"
+            title = "What?! Nobody rips off my kids but me!"
+            campaign = "MomCorp Galactic Domination Plot 3201"
+            duration = 60000
+            creative = "A Fistful of Dollars"
+            siteId = "moms"
+            placement = "first"
+            position = 0
+        }
+    }
+
+    @Test
+    fun mediaEventListener() {
+        mediaSession.mediaEventListener = { mediaEvent ->
+            if (mediaEvent.eventName == MediaEventName.PLAY) {
+                val mpEvent = mediaEvent.toMPEvent()
+                MParticle.getInstance()?.logEvent(mpEvent)
+            }
+        }
+    }
+
+    @Test
+    fun logPlayVariations() {
+        mediaSession.logPlay()
+        mediaSession.logPlay(Options(currentPlayheadPosition = 120000))
+    }
+
+    @Test
+    fun logAdBreakStartBuilder() {
+        mediaSession.logAdBreakStart {
+            id = "123456"
+            title = "pre-roll"
+            duration = 6000
+        }
+    }
+
+    @Test
+    fun optionsVariations() {
+        Options(
+            100,
+            mapOf(CONTENT_EPISODE to "episode1")
+        )
+
+        Options {
+            customAttributes = mapOf(
+                "isFullScreen" to "true",
+                CONTENT_EPISODE to "episode1",
+                PLAYER_NAME to "JWPlayer"
+            )
+            currentPlayheadPosition = 100
+        }
+    }
+
+    @Test
+    fun logError() {
+        mediaSession.logError("some error")
+        mediaSession.logError("some error", mapOf("with" to "attributes"))
     }
 }

--- a/media/src/test/java/com/mparticle/MediaEventToCustomEvent.kt
+++ b/media/src/test/java/com/mparticle/MediaEventToCustomEvent.kt
@@ -54,8 +54,8 @@ class MediaEventToCustomEvent {
         val customEvent = mediaEvent.toMPEvent()
         assertNotNull(customEvent)
         assertEquals(5, customEvent.customAttributes?.size)
-        customEvent.customAttributes?.apply {
-            assertMediaSessionPresent(mediaSession, customEvent.customAttributes!!)
+        customEvent.customAttributes?.also {
+            assertMediaSessionPresent(mediaSession, it)
         }
     }
 
@@ -83,10 +83,10 @@ class MediaEventToCustomEvent {
         val customEvent = mediaEvent.toMPEvent()
         assertNotNull(customEvent)
         assertEquals(7, customEvent.customAttributes?.size)
-        customEvent.customAttributes?.apply {
-            assertMediaSessionPresent(mediaSession, customEvent.customAttributes!!)
-            assertEquals(mediaSession.sessionId, get(MediaAttributeKeys.MEDIA_SESSION_ID))
-            assertEquals(playhead.toString(), get(MediaAttributeKeys.PLAYHEAD_POSITION))
+        customEvent.customAttributes?.also {
+            assertMediaSessionPresent(mediaSession, it)
+            assertEquals(mediaSession.sessionId, it.get(MediaAttributeKeys.MEDIA_SESSION_ID))
+            assertEquals(playhead, it.get(MediaAttributeKeys.PLAYHEAD_POSITION))
         }
     }
 
@@ -119,16 +119,17 @@ class MediaEventToCustomEvent {
                 index = random.nextInt()
                 title = randomUtils.getAlphaNumericString(24)
             }
+            error = MediaError(randomUtils.getAlphaNumericString(24), randomUtils.getRandomAttributes(6, false))
         }
         val customEvent = mediaEvent.toMPEvent()
         assertNotNull(customEvent)
         customEvent.customAttributes!!.apply {
             assertMediaSessionPresent(mediaSession, customEvent.customAttributes!!)
 
-            assertEquals(mediaEvent.qos!!.startupTime.toString(), remove(MediaAttributeKeys.QOS_STARTUP_TIME))
-            assertEquals(mediaEvent.qos!!.droppedFrames.toString(), remove(MediaAttributeKeys.QOS_DROPPED_FRAMES))
-            assertEquals(mediaEvent.qos!!.fps.toString(), remove(MediaAttributeKeys.QOS_FRAMES_PER_SECOND))
-            assertEquals(mediaEvent.qos!!.bitRate.toString(), remove(MediaAttributeKeys.QOS_BITRATE))
+            assertEquals(mediaEvent.qos!!.startupTime, remove(MediaAttributeKeys.QOS_STARTUP_TIME))
+            assertEquals(mediaEvent.qos!!.droppedFrames, remove(MediaAttributeKeys.QOS_DROPPED_FRAMES))
+            assertEquals(mediaEvent.qos!!.fps, remove(MediaAttributeKeys.QOS_FRAMES_PER_SECOND))
+            assertEquals(mediaEvent.qos!!.bitRate, remove(MediaAttributeKeys.QOS_BITRATE))
 
             assertEquals(mediaEvent.mediaAd!!.creative, remove(MediaAttributeKeys.AD_CREATIVE))
             assertEquals(mediaEvent.mediaAd!!.title, remove(MediaAttributeKeys.AD_TITLE))
@@ -136,27 +137,32 @@ class MediaEventToCustomEvent {
             assertEquals(mediaEvent.mediaAd!!.siteId, remove(MediaAttributeKeys.AD_SITE_ID))
             assertEquals(mediaEvent.mediaAd!!.advertiser, remove(MediaAttributeKeys.AD_ADVERTISING_ID))
             assertEquals(mediaEvent.mediaAd!!.campaign, remove(MediaAttributeKeys.AD_CAMPAIGN))
-            assertEquals(mediaEvent.mediaAd!!.duration.toString(), remove(MediaAttributeKeys.AD_DURATION))
+            assertEquals(mediaEvent.mediaAd!!.duration, remove(MediaAttributeKeys.AD_DURATION))
             assertEquals(mediaEvent.mediaAd!!.placement, remove(MediaAttributeKeys.AD_PLACEMENT))
-            assertEquals(mediaEvent.mediaAd!!.position.toString(), remove(MediaAttributeKeys.AD_POSITION))
+            assertEquals(mediaEvent.mediaAd!!.position, remove(MediaAttributeKeys.AD_POSITION))
 
-            assertEquals(mediaEvent.adBreak!!.duration.toString(), remove(MediaAttributeKeys.AD_BREAK_DURATION))
+            assertEquals(mediaEvent.adBreak!!.duration, remove(MediaAttributeKeys.AD_BREAK_DURATION))
             assertEquals(mediaEvent.adBreak!!.title, remove(MediaAttributeKeys.AD_BREAK_TITLE))
             assertEquals(mediaEvent.adBreak!!.id, remove(MediaAttributeKeys.AD_BREAK_ID))
             
-            assertEquals(mediaEvent.segment!!.duration.toString(), remove(MediaAttributeKeys.SEGMENT_DURATION))
-            assertEquals(mediaEvent.segment!!.index.toString(), remove(MediaAttributeKeys.SEGMENT_INDEX))
+            assertEquals(mediaEvent.segment!!.duration, remove(MediaAttributeKeys.SEGMENT_DURATION))
+            assertEquals(mediaEvent.segment!!.index, remove(MediaAttributeKeys.SEGMENT_INDEX))
             assertEquals(mediaEvent.segment!!.title, remove(MediaAttributeKeys.SEGMENT_TITLE))
+
+            assertEquals(mediaEvent.error!!.message, remove(MediaAttributeKeys.ERROR_MESSAGE))
+            assertEquals(mediaEvent.error!!.attributes.toAssertableString(), (remove(MediaAttributeKeys.ERROR_ATTRIBUTES) as Map<String, Any?>).toAssertableString())
 
             assertEquals(0, size)
         }
     }
 
-    fun assertMediaSessionPresent(mediaSession: MediaSession, customAttributes: MutableMap<String, String>) {
+    fun <T,V> Map<T, V>.toAssertableString() = entries.sortedBy { it.key.toString() }.joinToString { "${it.key}:{${it.value}" }
+
+    fun assertMediaSessionPresent(mediaSession: MediaSession, customAttributes: MutableMap<String, Any?>) {
         assertEquals(mediaSession.contentType, customAttributes.remove(MediaAttributeKeys.CONTENT_TYPE))
         assertEquals(mediaSession.streamType, customAttributes.remove(MediaAttributeKeys.STREAM_TYPE))
         assertEquals(mediaSession.title, customAttributes.remove(MediaAttributeKeys.TITLE))
         assertEquals(mediaSession.mediaContentId, customAttributes.remove(MediaAttributeKeys.CONTENT_ID))
-        assertEquals(mediaSession.duration.toString(), customAttributes.remove(MediaAttributeKeys.DURATION))
+        assertEquals(mediaSession.duration, customAttributes.remove(MediaAttributeKeys.DURATION))
     }
 }

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -3,6 +3,7 @@ package com.mparticle
 import com.mparticle.media.MediaSession
 import com.mparticle.media.events.*
 import com.mparticle.testutils.RandomUtils
+import com.mparticle.testutils.TestingUtils
 import junit.framework.Assert.*
 import org.junit.Test
 import java.lang.reflect.Method
@@ -202,7 +203,7 @@ class MediaSessionTest  {
         fun testSessionMediaContentAttributes() {
             assertEquals(mediaSession.mediaContentId, attributes[MediaAttributeKeys.CONTENT_ID])
             assertEquals(mediaSession.title, attributes[MediaAttributeKeys.TITLE])
-            assertEquals(mediaSession.duration.toString(), attributes[MediaAttributeKeys.DURATION])
+            assertEquals(mediaSession.duration, attributes[MediaAttributeKeys.DURATION])
             assertEquals(mediaSession.contentType, attributes[MediaAttributeKeys.CONTENT_TYPE])
             assertEquals(mediaSession.streamType, attributes[MediaAttributeKeys.STREAM_TYPE])
         }
@@ -217,7 +218,7 @@ class MediaSessionTest  {
 
         attributes = mediaSession.attributes
         assertEquals(7, attributes.size)
-        assertEquals(10.toString(), attributes[MediaAttributeKeys.PLAYHEAD_POSITION])
+        assertEquals(10L, attributes[MediaAttributeKeys.PLAYHEAD_POSITION])
 
         //make sure no other Media Sessions are started
         afterLogApiInvoked(mediaSession) {}
@@ -254,9 +255,12 @@ class MediaSessionTest  {
             if (it.name != "logPlayheadPosition") {
                 assertTrue(it.toString(), mparticle.loggedEvents.size >= 1)
                 val event = mparticle.loggedEvents[0] as MediaEvent
-                assertTrue(it.toString(), event.customAttributes!!.containsKey("testKey1"))
+                if (event.customAttributes?.containsKey("testKey1") == false) {
+                    println("hi")
+                }
+                assertTrue(it.toString(), event.customAttributes?.containsKey("testKey1") ?: false)
                 assertTrue(it.toString(), event.customAttributes?.get("testKey1") == "testValue1")
-                assertTrue(it.toString(), event.customAttributes!!.containsKey("testKey2"))
+                assertTrue(it.toString(), event.customAttributes?.containsKey("testKey2") ?: false)
                 assertTrue(it.toString(), event.customAttributes?.get("testKey2") == "testValue2")
 
                 assertEquals(options.currentPlayheadPosition, mediaSession.currentPlayheadPosition)
@@ -382,6 +386,8 @@ class MediaSessionTest  {
                     arguments[i] = MediaQoS()
                 } else if (type == Options::class.java) {
                     arguments[i] = options
+                } else if (type == Map::class.java) {
+                    arguments[i] = RandomUtils.getInstance().getRandomAttributes(6, false)
                 } else {
                     throw RuntimeException("unknown type: " + type.name + "\nmethod: " + method.toString())
                 }


### PR DESCRIPTION
## Summary
Add a dedicated `logError(String, Map)` method to `MediaSession`. Previously, we suggested using the generic `MParticle#logError()` method for creating errors related to MediaSessions but when clients have concurrent `MediaSession`s, it has proved difficult to attribute the error to a specific instance. This new method will allow errors to be generated in the context of specific `MediaSession` instances, just like the other `MediaEvent`s

## Testing Plan
added unit tests

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4080
