### PR TITLE
fix: update release artifactId value

### DIFF
--- a/.scripts/maven.gradle
+++ b/.scripts/maven.gradle
@@ -12,7 +12,7 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 groupId = "com.mparticle"
-                artifactId = project.name
+                artifactId = "android-media"
                 version = project.version
                 if (project.plugins.findPlugin("com.android.library")) {
                     from components.release


### PR DESCRIPTION
## Summary
the Disney team notified us that they were having issues upgrading the media SDK from v1.3.1 to v1.4.0 as the dependency "com.mparticle:android-media:1.4.0" was failing and not recognized. We noticed that the artifactID compared to debug and v1.3.1 was different and was the reason behind this issue.

## Testing Plan
- Check MavenCentral after release


## Ticket Number
Closes https://go.mparticle.com/work/SQDSDKS-4295