### PR TITLE
fix:mediaContentTimeSpent logic fix

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -81,7 +81,7 @@ class MediaSession protected constructor(builder: Builder) {
         }
     private val mediaContentTimeSpent: Double
         get() { //total seconds spent playing content
-            return currentPlayheadPosition?.let {
+            return currentPlaybackStartTimestamp?.let {
                 this.storedPlaybackTime + (System.currentTimeMillis().minus(it) / 1000).toDouble()
             } ?: this.storedPlaybackTime
         }


### PR DESCRIPTION
## Summary
- Closes https://github.com/mParticle/mparticle-android-media-sdk/issues/13

## Testing Plan
- Was tested locally and worked as expected. Also, with this fix it matches other media SDKs (iOS and Web) that are working as expected

## References
- Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-5372