### PR TITLE
Fix: Fix mediaContentComplete calculation

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -601,8 +601,12 @@ class MediaSession protected constructor(builder: Builder) {
             mparticleInstance = MParticle.getInstance()
         }
 
+        // These local variables prevent the use of !! in the if statement that could potentially throw a NullPointerException.
+        val duration = this.duration
+        val currentPlayheadPosition = this.currentPlayheadPosition
+
         mediaSessionEndTimestamp = System.currentTimeMillis()
-        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
+        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition / duration.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
             mediaContentComplete = true
         }
 

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -601,12 +601,8 @@ class MediaSession protected constructor(builder: Builder) {
             mparticleInstance = MParticle.getInstance()
         }
 
-        // These local variables prevent the use of !! in the if statement that could potentially throw a NullPointerException.
-        val duration = this.duration
-        val currentPlayheadPosition = this.currentPlayheadPosition
-
         mediaSessionEndTimestamp = System.currentTimeMillis()
-        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition / duration.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
+        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
             mediaContentComplete = true
         }
 

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -602,7 +602,7 @@ class MediaSession protected constructor(builder: Builder) {
         }
 
         mediaSessionEndTimestamp = System.currentTimeMillis()
-        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!) >= (mediaContentCompleteLimit / 100))) {
+        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
             mediaContentComplete = true
         }
 


### PR DESCRIPTION
## Summary
In logEvent(), the condition that is checking if the content ended was using an integer division, ending with a result like this: 

```
((currentPlayheadPosition!! / duration!!) >= (mediaContentCompleteLimit / 100))

((80 / 100) >= (85 / 100))

((0) >= (0))

true
```

Now, we have:

```
((currentPlayheadPosition!! / duration!!.toDouble()) >= (mediaContentCompleteLimit / 100.0))

((80 / 100) >= (85 / 100))

((0.8) >= (0.85))

false
```

## Testing Plan

## Reference Issue