### PR TITLE
ci: Update Java version, pin conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
           -p @semantic-release/exec@5 \
-          -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog-conventionalcommits@7 \
           semantic-release --dry-run
       - name: "Semantic Release"
         if: ${{ github.event.inputs.dryRun == 'false' }}
@@ -51,7 +51,7 @@ jobs:
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
           -p @semantic-release/exec@5 \
-          -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog-conventionalcommits@7 \
           semantic-release
       - name: "Push automated release commits to release branch"
         if: ${{ github.event.inputs.dryRun == 'false' }}
@@ -73,11 +73,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           cache: "gradle"
       - name: "Publish Android To Sonatype"
         run: |


### PR DESCRIPTION
## Summary
- Update Java version to 17, pin conventional commits to 7

## Testing Plan
- N/A

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME
