### PR TITLE
fix: Pause mediaContentTimeSpent when logMediaContentEnd is triggered

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -174,6 +174,10 @@ class MediaSession protected constructor(builder: Builder) {
      */
     fun logMediaContentEnd(options: Options? = null) {
         mediaContentComplete = true
+        currentPlaybackStartTimestamp?.let {
+            storedPlaybackTime += ((System.currentTimeMillis() - it) / 1000)
+            currentPlaybackStartTimestamp = null;
+        }
         val mediaSessionEvent = MediaEvent(this, MediaEventName.CONTENT_END, options = options)
         logEvent(mediaSessionEvent)
     }

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -602,7 +602,7 @@ class MediaSession protected constructor(builder: Builder) {
         }
 
         mediaSessionEndTimestamp = System.currentTimeMillis()
-        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!) >= (mediaContentCompleteLimit / 100))) {
+        if (mediaContentCompleteLimit < 100 && (duration != null && currentPlayheadPosition != null) && ((currentPlayheadPosition!! / duration!!.toDouble()) >= (mediaContentCompleteLimit / 100.0))) {
             mediaContentComplete = true
         }
 

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -4,6 +4,8 @@ import com.mparticle.media.MediaSession
 import com.mparticle.media.events.*
 import com.mparticle.testutils.RandomUtils
 import junit.framework.Assert.*
+import org.junit.Assert
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import java.lang.reflect.Method
 import java.util.*
@@ -476,6 +478,61 @@ class MediaSessionTest  {
         override fun logEvent(baseEvent: BaseEvent) {
             loggedEvents.add(baseEvent)
         }
+    }
+
+    @Test
+    fun testLogMediaContentEnd() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+        }
+
+        // logPlay is triggered to start media content time tracking.
+        mediaSession.logPlay()
+        // 1s delay added to account for the time spent on media content.
+        Thread.sleep(1000)
+        mediaSession.logMediaContentEnd()
+        // Another 1s delay added after logMediaContentEnd is triggered to
+        // account for time spent on media session (total = 2s).
+        Thread.sleep(1000)
+        mediaSession.logMediaSessionEnd()
+
+        val testContentTimeSpent = mediaSession.mediaContentTimeSpent
+        val testTimeSpent = mediaSession.mediaTimeSpent
+
+        println(testContentTimeSpent)
+        assertNotEquals(testContentTimeSpent, testTimeSpent)
+        assertEquals(testContentTimeSpent, 1.0)
+        assertEquals(testTimeSpent, 2.0)
+    }
+
+    @Test
+    fun testLogPause() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+        }
+
+        // logPlay is triggered to start media content time tracking.
+        mediaSession.logPlay()
+        // 1s delay added to account for the time spent on media content.
+        Thread.sleep(1000)
+        mediaSession.logPause()
+        // Another 1s delay added after logMediaContentEnd is triggered to
+        // account for time spent on media session (total = 2s).
+        Thread.sleep(1000)
+        mediaSession.logMediaSessionEnd()
+
+        val testContentTimeSpent = mediaSession.mediaContentTimeSpent
+        val testTimeSpent = mediaSession.mediaTimeSpent
+
+        assertNotEquals(testContentTimeSpent, testTimeSpent)
+        assertEquals(testContentTimeSpent, 1.0)
+        assertEquals(testTimeSpent, 2.0)
     }
 }
 

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -502,7 +502,6 @@ class MediaSessionTest  {
         val testContentTimeSpent = mediaSession.mediaContentTimeSpent
         val testTimeSpent = mediaSession.mediaTimeSpent
 
-        println(testContentTimeSpent)
         assertNotEquals(testContentTimeSpent, testTimeSpent)
         assertEquals(testContentTimeSpent, 1.0)
         assertEquals(testTimeSpent, 2.0)

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -521,7 +521,7 @@ class MediaSessionTest  {
         // 1s delay added to account for the time spent on media content.
         Thread.sleep(1000)
         mediaSession.logPause()
-        // Another 1s delay added after logMediaContentEnd is triggered to
+        // Another 1s delay added after logPause is triggered to
         // account for time spent on media session (total = 2s).
         Thread.sleep(1000)
         mediaSession.logMediaSessionEnd()


### PR DESCRIPTION
## Summary
- When a logMediaContentEnd event is called, it does not stop the counter for mediaContentTimeSpent Therefore, even when the consumer finishes content but doesn't complete the media session, the mediaContentTimeSpent counter increases. Currently, only logPause and logMediaSessionEnd will stop the mediaContentTimeSpent counter. This pr is to allow the mediaContentTimeSpent to be paused when a logMediaContentEnd is triggered

## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-7165
