### PR TITLE
fix: handle ad_break_id key in the ad Summary event

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -78,6 +78,7 @@ class MediaSession protected constructor(builder: Builder) {
 
     private var adContent: MediaAd? = null
     private var segment: MediaSegment? = null
+    private var mediaAdBreak: MediaAdBreak? = null
 
     var mediaSessionStartTimestamp: Long //Timestamp created on logMediaSessionStart event
         private set
@@ -283,6 +284,7 @@ class MediaSession protected constructor(builder: Builder) {
         val adBreakEvent = MediaEvent(this, MediaEventName.AD_BREAK_START, options = options).apply {
             this.adBreak = adBreak
         }
+        mediaAdBreak = adBreak
         logEvent(adBreakEvent)
     }
 
@@ -337,6 +339,9 @@ class MediaSession protected constructor(builder: Builder) {
             mediaTotalAdTimeSpent += ((endTime - startTime) / 1000)
         }
         val adEndEvent = MediaEvent(this, MediaEventName.AD_END, options = options)
+        mediaAdBreak?.let {
+            adContent?.adBreakId = it.id
+        }
         logEvent(adEndEvent)
 
         logAdSummary(adContent)
@@ -589,6 +594,9 @@ class MediaSession protected constructor(builder: Builder) {
             }
             ad.title?.let {
                 customAttributes[adContentTitleKey] = it
+            }
+            ad.adBreakId?.let {
+                customAttributes[adBreakIdKey] = it
             }
             customAttributes[adContentSkippedKey] = ad.adSkipped.toString()
             customAttributes[adContentCompletedKey] = ad.adCompleted.toString()

--- a/media/src/main/java/com/mparticle/media/events/MediaAd.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaAd.kt
@@ -19,5 +19,6 @@ class MediaAd(
     internal var adStartTimestamp: Long? = null,
     internal var adEndTimestamp: Long? = null,
     internal var adSkipped: Boolean = false,
-    internal var adCompleted: Boolean = false
+    internal var adCompleted: Boolean = false,
+    internal var adBreakId: String? = null
 )

--- a/media/src/main/java/com/mparticle/media/events/MediaEvent.kt
+++ b/media/src/main/java/com/mparticle/media/events/MediaEvent.kt
@@ -176,6 +176,7 @@ open class MediaEvent(
         adBreak?.apply {
             json.put(
                 "adBreak", JSONObject()
+                    .put("id",id)
                     .put("title", title)
                     .put("duration", duration)
             )

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -533,6 +533,70 @@ class MediaSessionTest  {
         assertEquals(testContentTimeSpent, 1.0)
         assertEquals(testTimeSpent, 2.0)
     }
+
+    @Test
+    fun testLogAdSummary() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+        }
+
+        val events = mutableListOf<MediaEvent>()
+        mediaSession.mediaEventListener = { event ->
+            events.add(event)
+        }
+        mediaSession.logAdStart {  }
+        mediaSession.logAdBreakStart {
+            id = "123456"
+            title = "TestADBREAk"
+        }
+        mediaSession.logAdEnd()
+        mediaSession.logAdBreakEnd()
+        assertEquals(4, events.size)
+        events.forEach {
+            it.mediaContent.apply {
+                assertEquals("hello", name)
+                assertEquals("123", contentId)
+                assertEquals(1000L, duration)
+            }
+        }
+        assertNotNull(mparticle.loggedEvents[3].customAttributes)
+        assertNotNull(mparticle.loggedEvents[3].customAttributes?.get("ad_break_id"))
+        assertEquals("123456",mparticle.loggedEvents[3].customAttributes?.get("ad_break_id"))
+    }
+
+    @Test
+    fun testLogAdSummary_When_Break_ID_IS_NULL() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+        }
+
+        val events = mutableListOf<MediaEvent>()
+        mediaSession.mediaEventListener = { event ->
+            events.add(event)
+        }
+        mediaSession.logAdStart {  }
+        mediaSession.logAdBreakStart {
+            title = "TestADBREAk"
+        }
+        mediaSession.logAdEnd()
+        mediaSession.logAdBreakEnd()
+        assertEquals(4, events.size)
+        events.forEach {
+            it.mediaContent.apply {
+                assertEquals("hello", name)
+                assertEquals("123", contentId)
+                assertEquals(1000L, duration)
+            }
+        }
+        assertNotNull(mparticle.loggedEvents[3].customAttributes)
+        assertNull(mparticle.loggedEvents[3].customAttributes?.get("ad_break_id"))
+    }
 }
 
 fun <T: Any> T.assertTrue(assertion: (T) -> Boolean) {


### PR DESCRIPTION
## Instructions
1. PR target branch should be against main
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
- This PR adds the ad_break_id to the ad_summary event. It was missing before.

## Testing Plan
- Tested it with the sample app and here’s a screenshot of the live stream. 
Before :
<img width="1336" alt="Screenshot 2025-06-11 at 5 33 31 PM" src="https://github.com/user-attachments/assets/37f0a8a5-e2c9-41b0-b5c1-0d9bff0dd5f3" />


After : 
<img width="1394" alt="Screenshot 2025-05-22 at 4 11 54 PM" src="https://github.com/user-attachments/assets/75fea580-3b68-4418-be3a-cb639fbef6f0" />


## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-7264
