### PR TITLE
feat: Calculate mediaTimeSpent based on current time

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -85,8 +85,8 @@ class MediaSession protected constructor(builder: Builder) {
     var mediaSessionEndTimestamp: Long //Timestamp updated when any event is logged
         private set
     val mediaTimeSpent: Double
-        get() { //total seconds between media session start and end time
-            return ((this.mediaSessionEndTimestamp - mediaSessionStartTimestamp) / 1000).toDouble()
+        get() { //total seconds between media session start and current timestamp
+            return ((System.currentTimeMillis() - mediaSessionStartTimestamp) / 1000).toDouble()
         }
     val mediaContentTimeSpent: Double
         get() { //total seconds spent playing content

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -540,6 +540,29 @@ class MediaSessionTest  {
     }
 
     @Test
+    fun testMediaTimeSpent() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+        }
+
+        // logPlay is triggered to start media content time tracking.
+        mediaSession.logPlay()
+        // 1s delay added to account for the time spent on media content.
+        Thread.sleep(1000)
+        mediaSession.logPause()
+        // Another 1s delay added after logPause is triggered to
+        // account for time spent on media session (total = 2s).
+        Thread.sleep(1000)
+
+        // mediaTimeSpent should be = 2s even though the last media event logged was 1s ago
+        val testTimeSpent = mediaSession.mediaTimeSpent
+        assertEquals(testTimeSpent, 2.0)
+    }
+
+    @Test
     fun testLogMediaContentEnd() {
         val mparticle = MockMParticle()
         val mediaSession = MediaSession.builder(mparticle) {


### PR DESCRIPTION
## Summary
- A customer noticed that the getter for mediaTimeSpent calculates the value based on the difference between mediaSessionEndTimestamp and mediaSessionStartTimestamp, which leads to inaccuracy since mediaSessionEndTimestamp is only updated when logging a media event, with this PR it now calculates based on on the difference between System.currentTimeMillis() (current time) and mediaSessionStartTimestamp

## Testing Plan
- E2E and unit tested

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-7273
