### PR TITLE
fix: adjust ad break exclusion logic

### DIFF
--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -119,6 +119,7 @@ class MediaSession protected constructor(builder: Builder) {
     var storedPlaybackTime: Double = 0.0 //On Pause calculate playback time and clear currentPlaybackTime
         private set
     private var sessionSummarySent = false // Ensures we only send summary event once
+    private var pausedByAdBreak: Boolean = false // Tracks if content was paused by an ad break (for resume logic)
 
     private var testing = false // Enabled for test cases
 
@@ -579,15 +580,21 @@ class MediaSession protected constructor(builder: Builder) {
             currentPlaybackStartTimestamp?.let {
                 storedPlaybackTime += ((System.currentTimeMillis() - it) / 1000)
                 currentPlaybackStartTimestamp = null
+                pausedByAdBreak = true
+            } ?: run {
+                // Content was already paused, don't mark as paused by ad break
+                pausedByAdBreak = false
             }
         }
     }
 
     private fun resumeContentTimeIfAdBreakExclusionEnabled() {
         if (excludeAdBreaksFromContentTime) {
-            if (currentPlaybackStartTimestamp != null) {
+            // Only resume if content was paused by the ad break, not if it was already paused
+            if (pausedByAdBreak && currentPlaybackStartTimestamp == null) {
                 currentPlaybackStartTimestamp = System.currentTimeMillis()
             }
+            pausedByAdBreak = false
         }
     }
 

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -575,7 +575,7 @@ class MediaSession protected constructor(builder: Builder) {
     }
 
     private fun pauseContentTimeIfAdBreakExclusionEnabled() {
-        if (!excludeAdBreaksFromContentTime) {
+        if (excludeAdBreaksFromContentTime) {
             currentPlaybackStartTimestamp?.let {
                 storedPlaybackTime += ((System.currentTimeMillis() - it) / 1000)
                 currentPlaybackStartTimestamp = null
@@ -584,7 +584,7 @@ class MediaSession protected constructor(builder: Builder) {
     }
 
     private fun resumeContentTimeIfAdBreakExclusionEnabled() {
-        if (!excludeAdBreaksFromContentTime) {
+        if (excludeAdBreaksFromContentTime) {
             if (currentPlaybackStartTimestamp != null) {
                 currentPlaybackStartTimestamp = System.currentTimeMillis()
             }
@@ -777,10 +777,10 @@ class MediaSession protected constructor(builder: Builder) {
         }
 
         /**
-         * When enabled, automatically pauses content time tracking during ad breaks and resumes after.
+         * When enabled, ad break time is excluded from content time tracking.
          * When disabled (default), ad break time is included in content time spent.
          */
-        fun pauseContentDuringAdBreaks(shouldPause: Boolean): Builder {
+        fun excludeAdBreaksFromContentTime(shouldPause: Boolean): Builder {
             this.excludeAdBreaksFromContentTime = shouldPause
             return this
         }

--- a/media/src/main/java/com/mparticle/media/MediaSession.kt
+++ b/media/src/main/java/com/mparticle/media/MediaSession.kt
@@ -91,7 +91,7 @@ class MediaSession protected constructor(builder: Builder) {
     val mediaContentTimeSpent: Double
         get() { //total seconds spent playing content
             return currentPlaybackStartTimestamp?.let {
-                this.storedPlaybackTime + (System.currentTimeMillis().minus(it) / 1000).toDouble()
+                this.storedPlaybackTime + (System.currentTimeMillis() - it) / 1000.0
             } ?: this.storedPlaybackTime
         }
     var mediaContentCompleteLimit: Int = 100
@@ -119,7 +119,7 @@ class MediaSession protected constructor(builder: Builder) {
     var storedPlaybackTime: Double = 0.0 //On Pause calculate playback time and clear currentPlaybackTime
         private set
     private var sessionSummarySent = false // Ensures we only send summary event once
-    private var pausedByAdBreak: Boolean = false // Tracks if content was paused by an ad break (for resume logic)
+    private var playbackState: PlaybackState = PlaybackState.PAUSED_BY_USER // Tracks whether playback was playing, paused, or paused by ad break
 
     private var testing = false // Enabled for test cases
 
@@ -192,6 +192,8 @@ class MediaSession protected constructor(builder: Builder) {
         if (currentPlaybackStartTimestamp == null) {
             currentPlaybackStartTimestamp = System.currentTimeMillis()
         }
+        
+        playbackState = PlaybackState.PLAYING
         val playEvent = MediaEvent(this, MediaEventName.PLAY, options = options)
         logEvent(playEvent)
     }
@@ -204,6 +206,8 @@ class MediaSession protected constructor(builder: Builder) {
             storedPlaybackTime += ((System.currentTimeMillis() - it) / 1000)
             currentPlaybackStartTimestamp = null;
         }
+        
+        playbackState = PlaybackState.PAUSED_BY_USER
         val pauseEvent = MediaEvent(this, MediaEventName.PAUSE, options = options)
         logEvent(pauseEvent)
     }
@@ -576,34 +580,30 @@ class MediaSession protected constructor(builder: Builder) {
     }
 
     private fun pauseContentTimeIfAdBreakExclusionEnabled() {
-        if (excludeAdBreaksFromContentTime) {
-            currentPlaybackStartTimestamp?.let {
-                storedPlaybackTime += ((System.currentTimeMillis() - it) / 1000)
-                currentPlaybackStartTimestamp = null
-                pausedByAdBreak = true
-            } ?: run {
-                // Content was already paused, don't mark as paused by ad break
-                pausedByAdBreak = false
-            }
+        if (!excludeAdBreaksFromContentTime || playbackState != PlaybackState.PLAYING) return
+
+        currentPlaybackStartTimestamp?.let {
+            storedPlaybackTime += (System.currentTimeMillis() - it) / 1000.0
+            currentPlaybackStartTimestamp = null
+            playbackState = PlaybackState.PAUSED_BY_AD_BREAK
         }
     }
 
     private fun resumeContentTimeIfAdBreakExclusionEnabled() {
-        if (excludeAdBreaksFromContentTime) {
-            // Only resume if content was paused by the ad break, not if it was already paused
-            if (pausedByAdBreak && currentPlaybackStartTimestamp == null) {
-                currentPlaybackStartTimestamp = System.currentTimeMillis()
-            }
-            pausedByAdBreak = false
-        }
+        if (!excludeAdBreaksFromContentTime || playbackState != PlaybackState.PAUSED_BY_AD_BREAK) return
+
+        currentPlaybackStartTimestamp = System.currentTimeMillis()
+        playbackState = PlaybackState.PLAYING
     }
 
     private fun logAdSummary(content: MediaAd?) {
         content?.let { ad ->
             ad.adStartTimestamp?.let { startTime ->
-                val endTime = System.currentTimeMillis()
-                ad.adEndTimestamp = endTime
-                mediaTotalAdTimeSpent += ((endTime - startTime) / 1000).toDouble()
+                val endTime = ad.adEndTimestamp ?: System.currentTimeMillis()
+                if (ad.adEndTimestamp == null) {
+                    ad.adEndTimestamp = endTime
+                    mediaTotalAdTimeSpent += ((endTime - startTime) / 1000).toDouble()
+                }
             }
 
             val customAttributes: MutableMap<String, String> = mutableMapOf()
@@ -800,6 +800,12 @@ class MediaSession protected constructor(builder: Builder) {
         }
     }
 
+}
+
+private enum class PlaybackState {
+    PLAYING,
+    PAUSED_BY_USER,
+    PAUSED_BY_AD_BREAK
 }
 
 private fun String?.require(variableName: String): String {

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -679,7 +679,7 @@ class MediaSessionTest  {
     }
 
     @Test
-    fun testContentTimeExcludesAdBreak_When_Flag_Disable() {
+    fun testExcludeAdBreaksFromContentTime_Default_Disabled_IncludesAdTime() {
         val mparticle = MockMParticle()
         val events = mutableListOf<MediaEvent>()
         val mediaSession = MediaSession.builder(mparticle) {
@@ -710,7 +710,7 @@ class MediaSessionTest  {
     }
 
     @Test
-    fun testDefaultBehavior_Unchanged_When_Flag_Enable() {
+    fun testExcludeAdBreaksFromContentTime_Enabled_ExcludesAdTime() {
         val mparticle = MockMParticle()
         val mediaSession = MediaSession.builder(mparticle) {
             title = "hello"
@@ -724,9 +724,35 @@ class MediaSessionTest  {
         mediaSession.logAdBreakStart {
             id = "break-2"
         }
-        Thread.sleep(1000) // should count toward content time when flag disabled
+        Thread.sleep(1000)
         mediaSession.logAdBreakEnd()
         mediaSession.logPause()
+
+        val contentTime = mediaSession.mediaContentTimeSpent
+        assertEquals(1.0, contentTime, 0.2)
+    }
+
+    @Test
+    fun testExcludeAdBreaksFromContentTime_UserPausesMidAd_ThenAdBreakEnds() {
+        val mparticle = MockMParticle()
+        val mediaSession = MediaSession.builder(mparticle) {
+            title = "hello"
+            mediaContentId ="123"
+            duration =1000
+            excludeAdBreaksFromContentTime = true
+        }
+
+        mediaSession.logPlay()
+        Thread.sleep(1000)
+
+        mediaSession.logAdBreakStart {
+            id = "break-3"
+        }
+        Thread.sleep(1000)
+
+        mediaSession.logPause()
+
+        mediaSession.logAdBreakEnd()
 
         val contentTime = mediaSession.mediaContentTimeSpent
         assertEquals(1.0, contentTime, 0.2)

--- a/media/src/test/java/com/mparticle/MediaSessionTest.kt
+++ b/media/src/test/java/com/mparticle/MediaSessionTest.kt
@@ -695,13 +695,13 @@ class MediaSessionTest  {
         mediaSession.logAdBreakStart {
             id = "break-1"
         }
-        Thread.sleep(1000) // should NOT count toward content time
+        Thread.sleep(1000) 
         mediaSession.logPause()
         mediaSession.logAdBreakEnd()
 
 
         val contentTime = mediaSession.mediaContentTimeSpent
-        assertEquals(1.0, contentTime)
+        assertEquals(2.0, contentTime, 0.2)
 
         val playCount = events.count { it.eventName == MediaEventName.PLAY }
         val pauseCount = events.count { it.eventName == MediaEventName.PAUSE }
@@ -729,7 +729,7 @@ class MediaSessionTest  {
         mediaSession.logPause()
 
         val contentTime = mediaSession.mediaContentTimeSpent
-        assertEquals(2.0, contentTime)
+        assertEquals(1.0, contentTime, 0.2)
     }
 }
 


### PR DESCRIPTION
## Instructions
1. PR target branch should be against main
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
- pauseContentDuringAdBreaks renamed to excludeAdBreaksFromContentTime to accurately describe behavior.
Updated boolean flag usage for clarity.
Test cases modified to remove flaky timing assertions and ensure correctness.

## Testing Plan
- Tested with sample app 

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME
