### PR TITLE
fix: pin android-core upper bound to prevent 6.0.0-rc.1 pull

### DIFF
--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -26,7 +26,9 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
-    implementation("com.mparticle:android-core:[5.11.3,)")
+    // Bounded upper bound prevents resolving to 6.0.0-rc.1+ on Maven Central.
+    // See mparticle-android-sdk#710 for context.
+    implementation("com.mparticle:android-core:[5.11.3,6.0)")
 
     testImplementation(files("libs/test-utils.aar"))
     testImplementation(files("libs/java-json.jar"))


### PR DESCRIPTION
## Summary

- Replace open-ended `com.mparticle:android-core:[5.11.3,)` range with `[5.11.3,6.0)` in `media/build.gradle.kts`.

## Why

`com.mparticle:android-core:6.0.0-rc.1` was published to Maven Central on 2026-05-22. The unbounded range resolves to the highest available version, which is now the RC. 6.x removed deprecated symbols, breaking downstream consumers.

See mParticle/mparticle-android-sdk#710 for the broader incident affecting all Android consumers using dynamic ranges.

## Test plan

- [ ] `./gradlew :media:assembleRelease` resolves a 5.x android-core (not 6.0.0-rc.1).
- [ ] Downstream apps consuming `mparticle-android-media-sdk` still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)